### PR TITLE
fix double log printing 

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -6,21 +6,28 @@ import addon
 
 
 class XBMCHandler(logging.StreamHandler):
-    xbmc_levels = {
-        'DEBUG': 0,
-        'INFO': 2,
-        'WARNING': 3,
-        'ERROR': 4,
-        'CRITICAL': 5,
-    }
+    def __init__(self):
+        logging.StreamHandler.__init__(self)
+        formatter = logging.Formatter("[%(name)s] %(message)s")
+        self.setFormatter(formatter)
 
     def emit(self, record):
-        xbmc_level = self.xbmc_levels.get(record.levelname)
-        xbmc.log(self.format(record), xbmc_level)
+        levels = {
+            logging.CRITICAL: xbmc.LOGFATAL,
+            logging.ERROR: xbmc.LOGERROR,
+            logging.WARNING: xbmc.LOGWARNING,
+            logging.INFO: xbmc.LOGINFO,
+            logging.DEBUG: xbmc.LOGDEBUG,
+            logging.NOTSET: xbmc.LOGNONE,
+        }
+        xbmc.log(self.format(record), levels[record.levelno])
+
+    def flush(self):
+        pass
 
 
 log = logging.getLogger(addon.ID)
+log.handlers = []
 
-handler = XBMCHandler()
-handler.setFormatter(logging.Formatter('[%(name)s] %(message)s'))
-log.addHandler(handler)
+log.addHandler(XBMCHandler())
+


### PR DESCRIPTION
fix for https://github.com/fugkco/script.elementum.jackett/issues/24

I was not able to understood the root cause. But `getlogger()` returns logger with handler. Adding additional handler with same text somehow shifts the log lvl for one of the identical msg's. 
So removing initial handler, leaving original `XBMCHandler`(or vise versa) results in one print - wrong log level.

I have removed initial handler and rewrote Handler, now levels are correct. 