### PR TITLE
fix resolution type

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -19,9 +19,9 @@ resolutions = OrderedDict([
     ('4k', [r'4k', r'2160[p]', r'uhd', r'4k', r'hd4k']),
     ('2k', [r'1440[p]', r'2k']),
     ('1080p', [r'1080[ip]', r'1920x1080', r'hd1080p?', r'fullhd', r'fhd', r'blu\W*ray', r'bd\W*remux']),
-    ('720p', [r'720[p]', r'1280x720', r'hd720p?', r'hd\-?rip', r'b[rd]rip']),
-    ('480p', [r'480[p]', r'xvid', r'dvd', r'dvdrip', r'hdtv', r'web\-(dl)?rip', r'iptv', r'sat\-?rip',
-              r'tv\-?rip']),
+    ('720p', [r'720[p]', r'1280x720', r'hd720p?', r'hd\-?rip', r'b[rd]rip', r'xvid', r'dvd', r'dvdrip', r'hdtv',
+              r'web\-(dl)?rip', r'iptv']),
+    ('480p', [r'480[p]', r'sat\-?rip', r'tv\-?rip']),
     ('240p', [r'240[p]', r'vhs\-?rip']),
     (UNKNOWN, []),
 ])


### PR DESCRIPTION
I'm currently trying to disable 480p in settings. 
But lots of 720p+ torrents are under targeted types.